### PR TITLE
Added missing "filename" option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(file) {
     }
 
     var end = function() {
-        this.queue(wrap(ejs.compile(input, {client: true, compileDebug: false})))
+        this.queue(wrap(ejs.compile(input, {client: true, compileDebug: false, filename: file})))
         this.queue(null)
     }
 


### PR DESCRIPTION
Hey!

Absence of the "filename" option caused error "Error: filename option is required for includes".
