### PR TITLE
Update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ejs",
     "transform"
   ],
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previous package version, that stored at npm registry does not include changes from https://github.com/unfold/browserify-ejs/pull/1 . Npm link - https://registry.npmjs.org/browserify-ejs/-/browserify-ejs-0.0.2.tgz
